### PR TITLE
noscript image fix

### DIFF
--- a/lib/matomo/view_helpers.rb
+++ b/lib/matomo/view_helpers.rb
@@ -12,7 +12,7 @@ module Matomo
     def matomo_tracking_embed
       content_tag(:div, id: "anon-stats") do
         content_tag(:noscript) do
-          content_tag(:img, src: matomo_tracking_url, style: "border:0", alt: "")
+          tag(:img, src: matomo_tracking_url, style: "border:0", alt: "")
         end +
         javascript_tag do
           "document.getElementById('anon-stats').innerHTML = '<img src=\"#{matomo_tracking_url}\"?urlref=' + encodeURIComponent(document.referrer) + 'style=\"border:0\" alt=\"\" />';".html_safe


### PR DESCRIPTION
The noscript image is coming through as `<img>...</img>`, with the attributes used as content. Switching to the tag helper for empty elements fixes it.