### PR TITLE
Make action_name configurable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,33 @@
 PATH
   remote: .
   specs:
-    eff_matomo (0.2.2)
+    eff_matomo (0.2.3)
       activesupport
       httparty
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
+    activesupport (5.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     hashdiff (0.3.7)
-    httparty (0.16.2)
+    httparty (0.16.4)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.1.1)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     minitest (5.11.3)
     multi_xml (0.6.0)
     public_suffix (3.0.3)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This gem reads two environment variables:
 
 Add `<%= matomo_tracking_embed %>` to the footer of your application layout template.
 
+`{action_name = [NAME]}` can be passed to set the action name manually. Otherwise, eff_matomo will attempt to use a `page_title` helper or else omit the action name.
+
 ### Displaying Matomo data
 
 This gem provides allows users to import site usage data from Matomo to display in their application. It currently supports two types of data:

--- a/lib/matomo.rb
+++ b/lib/matomo.rb
@@ -8,7 +8,7 @@ module Matomo
   class Referrer
     attr_accessor :label, :visits
 
-    def initialize(params)
+    def initialize(params = {})
       @label = params["label"]
       @visits = params["nb_visits"] || 0
       @actions = params["nb_actions"] || 0
@@ -16,6 +16,7 @@ module Matomo
 
     def actions_per_visit
       return 0 unless @actions and @visits
+      return 0 if @visits == 0
       (@actions/@visits.to_f).round(1)
     end
 
@@ -37,7 +38,7 @@ module Matomo
   class Page
     attr_accessor :hits, :visits, :path
 
-    def initialize(path, params)
+    def initialize(path, params = {})
       @path = path
       @label = params["label"]
       @hits = params["nb_hits"] || 0

--- a/lib/matomo/version.rb
+++ b/lib/matomo/version.rb
@@ -1,3 +1,3 @@
 module Matomo
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/lib/matomo/view_helpers.rb
+++ b/lib/matomo/view_helpers.rb
@@ -1,23 +1,31 @@
 module Matomo
   module ViewHelpers
-    def matomo_tracking_url
+    def matomo_tracking_embed(opts = {})
+      content_tag(:div, id: "anon-stats") do
+        content_tag(:noscript) do
+          tag(:img, src: matomo_tracking_url(opts), style: "border:0", alt: "")
+        end +
+        javascript_tag do
+          "document.getElementById('anon-stats').innerHTML = '<img src=\"#{matomo_tracking_url(opts)}\"?urlref=' + encodeURIComponent(document.referrer) + 'style=\"border:0\" alt=\"\" />';".html_safe
+        end
+      end
+    end
+
+    def matomo_tracking_url(opts = {})
       "#{Matomo.base_url}/js/?" + {
         idsite: Matomo.site_id,
         rec: 1,
-        action_name: page_title,
+        action_name: action_name_or_default(opts[:action_name]),
         url: request.original_url
-      }.to_param
+      }.compact.to_param
     end
 
-    def matomo_tracking_embed
-      content_tag(:div, id: "anon-stats") do
-        content_tag(:noscript) do
-          tag(:img, src: matomo_tracking_url, style: "border:0", alt: "")
-        end +
-        javascript_tag do
-          "document.getElementById('anon-stats').innerHTML = '<img src=\"#{matomo_tracking_url}\"?urlref=' + encodeURIComponent(document.referrer) + 'style=\"border:0\" alt=\"\" />';".html_safe
-        end
-      end
+    private
+
+    def action_name_or_default(name)
+      return name unless name.nil?
+      return page_title if defined?(page_title)
+      return nil
     end
   end
 end

--- a/spec/matomo_spec.rb
+++ b/spec/matomo_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Matomo do
     end
 
     it "survives empty inputs" do
-      visit = Matomo::Referrer.new({})
+      visit = Matomo::Referrer.new()
       expect(visit.actions_per_visit).to eq(0)
     end
 


### PR DESCRIPTION
Realized this gem is calling `page_title`, which just happened to be defined for SEC and Action Center. This PR makes that configurable, but keeps the old behavior as a default for back-compatibility.